### PR TITLE
`gramma server start` support `--port`

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -146,4 +146,8 @@ yargs
     default: false,
     describe: "Treat the text as markdown",
   })
+  .option("port", {
+    type: "number",
+    describe: "Set the port number of local API server",
+  })
   .demandCommand().argv

--- a/src/commands/server.js
+++ b/src/commands/server.js
@@ -22,7 +22,10 @@ const server = async (argv, cfg) => {
   }
 
   if (argv.action === "start") {
-    await startServer(cfg, true)
+    await startServer(cfg, {
+      port: argv.port,
+      viaCommand: true,
+    })
     process.exit()
   }
 

--- a/src/server/startServer.js
+++ b/src/server/startServer.js
@@ -22,7 +22,7 @@ const pingServer = async (url) => {
   await pingServer(url)
 }
 
-const startServer = async (cfg, viaCommand = false) => {
+const startServer = async (cfg, {port, viaCommand = false} = {}) => {
   if (!cfg.global.server_path) {
     console.log(
       kleur.red(`Please install local server via: gramma server install`),
@@ -31,9 +31,8 @@ const startServer = async (cfg, viaCommand = false) => {
   }
 
   console.log("Starting local API server...")
-
   const PORT = await portfinder.getPortPromise({
-    port: 8081,
+    port: port !== undefined ? port : 8081,
   })
 
   const command = "java"
@@ -68,7 +67,7 @@ const startServer = async (cfg, viaCommand = false) => {
     configure("server_pid", server.pid, cfg, true, true)
   }
 
-  console.log(kleur.green(`API server started! PID: ${server.pid}`))
+  console.log(kleur.green(`API server started! PID: ${server.pid}, API URL: ${api_url}`))
 
   return { server, api_url }
 }


### PR DESCRIPTION
fix #29 

## Test Plan

```
$ ./src/cli.js server start --port 12345
Starting local API server...
Waiting for local API server...
Waiting for local API server...
Waiting for local API server...
API server started! PID: 63095, API URL: http://localhost:12345/v2/check

$ ./src/cli.js config api_url http://localhost:12345/v2/check
Done

$ ./src/cli.js listen "This sentence will be check interactively."
Language: English (US)
Resolved: 0 | Pending: 1
---------------------------------

Rule: grammar
Explanation: Consider using either the past participle “checked” or the present participle “checking” here.

Context: This sentence will be check interactively.
Suggested fix: 1) checked  2) checking

$ ./src/cli.js server stop
API server stopped!
```